### PR TITLE
Fix for HVAC_Action HVAC_Mode Missmatch

### DIFF
--- a/custom_components/zoned_heating/switch.py
+++ b/custom_components/zoned_heating/switch.py
@@ -209,7 +209,7 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         temperature_increase_per_state = [
             state[ATTR_TEMPERATURE] - state[ATTR_CURRENT_TEMPERATURE]
             for state in states
-            if state[ATTR_HVAC_ACTION] == HVACAction.HEATING
+            if state[ATTR_HVAC_ACTION] == HVACAction.HEATING and state[ATTR_HVAC_MODE] != HVACAction.OFF 
         ]
 
         override_active = False


### PR DESCRIPTION
Some thermostats (like _TZE200_hue3yfsn) will always report HVAC_Action as Heating regardless of the current state. 
As a consequence  state[ATTR_TEMPERATURE] is None which leads to the following error
```
2025-01-23 17:16:36.480 ERROR (Recorder) [homeassistant] Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/config/custom_components/zoned_heating/switch.py", line 203, in async_zone_state_changed
    await self.async_calculate_override()
  File "/config/custom_components/zoned_heating/switch.py", line 209, in async_calculate_override
    await self.async_calculate_override_offset()
  File "/config/custom_components/zoned_heating/switch.py", line 262, in async_calculate_override_offset
    state[ATTR_TEMPERATURE] - state[ATTR_CURRENT_TEMPERATURE]
```
This PR addresses that issue by also checking HVAC_MODE which represents the real state (off when the thermostat is turned off, heat for heating).