### PR TITLE
Added absolute temperature option

### DIFF
--- a/custom_components/zoned_heating/config_flow.py
+++ b/custom_components/zoned_heating/config_flow.py
@@ -56,6 +56,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self.zones = None
         self.max_setpoint = None
         self.controller_delay_time = None
+        self.absolute_mode = None
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""
@@ -162,13 +163,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         if user_input is not None:
             self.controller_delay_time = user_input.get(const.CONF_CONTROLLER_DELAY_TIME)
-
-            return self.async_create_entry(title="", data={
-                const.CONF_ZONES: self.zones,
-                const.CONF_CONTROLLER: self.controller,
-                const.CONF_MAX_SETPOINT: self.max_setpoint,
-                const.CONF_CONTROLLER_DELAY_TIME: self.controller_delay_time,
-            })
+            return await self.async_step_absolute_mode()
 
         default = self.config_entry.options.get(const.CONF_CONTROLLER_DELAY_TIME)
         if not default:
@@ -185,6 +180,36 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         vol.Coerce(int),
                         vol.Range(min=10, max=300)
                     )
+                }
+            )
+        )
+
+    async def async_step_absolute_mode(self, user_input=None):
+        """Handle options flow."""
+
+        if user_input is not None:
+            self.controller_delay_time = user_input.get(const.CONF_ABSOLUTE_MODE)
+
+            return self.async_create_entry(title="", data={
+                const.CONF_ZONES: self.zones,
+                const.CONF_CONTROLLER: self.controller,
+                const.CONF_MAX_SETPOINT: self.max_setpoint,
+                const.CONF_CONTROLLER_DELAY_TIME: self.controller_delay_time,
+                const.CONF_ABSOLUTE_MODE : self.absolute_mode
+            })
+
+        default = self.config_entry.options.get(const.CONF_ABSOLUTE_MODE)
+        if not default:
+            default = const.DEFAULT_ABSOLUTE_MODE
+
+        return self.async_show_form(
+            step_id=const.CONF_ABSOLUTE_MODE,
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        const.CONF_ABSOLUTE_MODE,
+                        default=default
+                    ): bool
                 }
             )
         )

--- a/custom_components/zoned_heating/const.py
+++ b/custom_components/zoned_heating/const.py
@@ -10,9 +10,11 @@ CONF_CONTROLLER = "controller"
 CONF_ZONES = "zones"
 CONF_MAX_SETPOINT = "max_setpoint"
 CONF_CONTROLLER_DELAY_TIME = "controller_delay_time"
+CONF_ABSOLUTE_MODE = "absolute_mode"
 
 DEFAULT_MAX_SETPOINT = 21
 DEFAULT_CONTROLLER_DELAY_TIME = 10
+DEFAULT_ABSOLUTE_MODE = False
 
 ATTR_OVERRIDE_ACTIVE = "override_active"
 ATTR_TEMPERATURE_INCREASE = "temperature_increase"

--- a/custom_components/zoned_heating/switch.py
+++ b/custom_components/zoned_heating/switch.py
@@ -340,10 +340,10 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         self._stored_controller_state = None
 
     async def async_update_override_setpoint(self, temperature_increase: float):
-        if(self._absolute_mode): 
-            self.async_update_override_setpoint_absolute(temperature_increase)
+        if self._absolute_mode:
+            await self.async_update_override_setpoint_absolute(temperature_increase)
         else: 
-            self.async_update_override_setpoint_offset(temperature_increase)
+            await self.async_update_override_setpoint_offset(temperature_increase)
 
     async def async_update_override_setpoint_absolute(self, temperature_increase: float):
         """Update the override setpoint of the controller"""

--- a/custom_components/zoned_heating/switch.py
+++ b/custom_components/zoned_heating/switch.py
@@ -203,6 +203,9 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
             await self.async_calculate_override()
 
     async def async_calculate_override(self):
+
+        _LOGGER.debug("Absolute control mode={}".format(self._absolute_mode))
+
         if self._absolute_mode:
             await self.async_calculate_override_absoulte()
         else:
@@ -340,6 +343,9 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         self._stored_controller_state = None
 
     async def async_update_override_setpoint(self, temperature_increase: float):
+        
+        _LOGGER.debug("Absolute control mode={}".format(self._absolute_mode))
+        
         if self._absolute_mode:
             await self.async_update_override_setpoint_absolute(temperature_increase)
         else: 

--- a/custom_components/zoned_heating/translations/en.json
+++ b/custom_components/zoned_heating/translations/en.json
@@ -24,9 +24,9 @@
       },
       "absolute_mode": {
         "title": "Configure Zoned Heating settings",
-        "description": "Controller setpoint is controlled by offset from current zone",
+        "description": "Controller setpoint is directly controlled by absolute TRV target temperature",
         "data": {
-          "absolute_mode": "Controller setpoint controlled by offset"
+          "absolute_mode": "Controller setpoint is TRV target temperature"
         }
       },
       "controller_delay_time": {

--- a/custom_components/zoned_heating/translations/en.json
+++ b/custom_components/zoned_heating/translations/en.json
@@ -22,6 +22,13 @@
           "max_setpoint": "Controller setpoint temperature limit"
         }
       },
+      "absolute_mode": {
+        "title": "Configure Zoned Heating settings",
+        "description": "Controller setpoint is controlled by offset from current zone",
+        "data": {
+          "absolute_mode": "Controller setpoint controlled by offset"
+        }
+      },
       "controller_delay_time": {
         "title": "Configure Zoned Heating settings",
         "description": "Time it takes for controller entity to reflect changes in setpoint",


### PR DESCRIPTION
In some use cases it can be better to set the controller setpoint_temperature as absolute value (according to a TRV) and not as an offset. 
This PR adds an option to do so, called absolute_mode (default:False).
In this mode, Zoned Heating will select the zone with the highest temperature difference (target-current) and set its TRV target_temp as new set_point for the controller unit. 
The original mode is not altered, just renamed (offset_mode) and a check is added when needed to switch between these modes for temp override calculations. 