### PR TITLE
Add HACS support

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,0 +1,15 @@
+name: HACS
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hacs/action@main
+        with:
+          category: integration
+          ignore: brands

--- a/custom_components/zoned_heating/manifest.json
+++ b/custom_components/zoned_heating/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "zoned_heating",
   "name": "Zoned Heating",
-  "version": "v1.1.3",
+  "version": "1.1.3",
   "documentation": "https://github.com/nielsfaber/zoned-heating",
   "issue_tracker": "https://github.com/nielsfaber/zoned-heating/issues",
   "dependencies": [

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "Zoned Heating",
+  "content_in_root": false,
+  "render_readme": true
+}


### PR DESCRIPTION
Sooooo, this should add HACS support, 

```
::INFO:: Category: integration
::INFO:: Repository: stinobook/zoned-heating@refs/heads/main
::INFO:: <Validation information> completed
::INFO:: <Validation description> completed
Error:  <Validation topics> failed:  The repository has no valid topics (More info: https://hacs.xyz/docs/publish/include#check-repository )
Error:  <Validation issues> failed:  The repository does not have issues enabled (More info: https://hacs.xyz/docs/publish/include#check-repository )
::INFO:: <Validation archived> completed
::INFO:: <Validation integration_manifest> completed
::INFO:: <Validation hacsjson> completed
Error:  <Integration stinobook/zoned-heating> 2/7 checks failed
```

on my fork I don't have topics or issues enabled so it fails for my fork.

And you've had the 'no HACS support yet' on this repo for ages now :D 

Note: readme not updated :)
