### PR TITLE
Add dynamic setting update without reload + add fixed controller mode

### DIFF
--- a/custom_components/zoned_heating/__init__.py
+++ b/custom_components/zoned_heating/__init__.py
@@ -26,9 +26,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # Set up all platforms for this device/entry.
     await hass.config_entries.async_forward_entry_setups(entry, [Platform.SWITCH])
 
-    # Reload entry when its updated.
-    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
-
     return True
 
 

--- a/custom_components/zoned_heating/config_flow.py
+++ b/custom_components/zoned_heating/config_flow.py
@@ -11,7 +11,9 @@ from homeassistant.components.climate import (
     ATTR_MIN_TEMP,
     ATTR_MAX_TEMP
 )
+from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import Platform
+from homeassistant.const import ATTR_TEMPERATURE
 from . import const
 
 _LOGGER = logging.getLogger(__name__)
@@ -57,13 +59,21 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self.zones = None
         self.max_setpoint = None
         self.controller_delay_time = None
+        self.use_fixed_idle_controller_state = None
+        self.fixed_idle_controller_mode = None
+        self.fixed_idle_controller_temperature = None
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""
 
         if user_input is not None:
             self.controller = user_input.get(const.CONF_CONTROLLER)
-            return await self.async_step_zones()
+            if not self.controller.startswith(Platform.CLIMATE):
+                self.use_fixed_idle_controller_state = False
+                self.fixed_idle_controller_mode = None
+                self.fixed_idle_controller_temperature = None
+                return await self.async_step_zones()
+            return await self.async_step_controller_idle_state()
 
         all_climates = [
             climate
@@ -89,6 +99,105 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ): vol.In(controller_options)
                 }
             )
+        )
+
+    async def async_step_controller_idle_state(self, user_input=None):
+        """Handle controller idle state strategy option."""
+
+        if user_input is not None:
+            self.use_fixed_idle_controller_state = user_input.get(
+                const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE
+            )
+            if not self.controller.startswith(Platform.CLIMATE):
+                self.use_fixed_idle_controller_state = False
+            if self.use_fixed_idle_controller_state and self.controller.startswith(Platform.CLIMATE):
+                return await self.async_step_fixed_idle_controller_state()
+
+            self.fixed_idle_controller_mode = None
+            self.fixed_idle_controller_temperature = None
+            return await self.async_step_zones()
+
+        default = self.options.get(
+            const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE,
+            const.DEFAULT_USE_FIXED_IDLE_CONTROLLER_STATE,
+        )
+        if not self.controller.startswith(Platform.CLIMATE):
+            default = False
+
+        schema = {
+            vol.Required(
+                const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE,
+                default=default,
+            ): bool
+        }
+
+        return self.async_show_form(
+            step_id="controller_idle_state",
+            data_schema=vol.Schema(schema),
+        )
+
+    async def async_step_fixed_idle_controller_state(self, user_input=None):
+        """Handle fixed controller idle mode and temperature options."""
+
+        controller_state = self.hass.states.get(self.controller)
+        if controller_state is None:
+            return await self.async_step_zones()
+
+        min_temp = 0
+        max_temp = 100
+        if self.controller.startswith(Platform.CLIMATE):
+            min_temp_attr = controller_state.attributes.get(ATTR_MIN_TEMP)
+            max_temp_attr = controller_state.attributes.get(ATTR_MAX_TEMP)
+            if isinstance(min_temp_attr, (int, float)):
+                min_temp = round(min_temp_attr)
+            if isinstance(max_temp_attr, (int, float)):
+                max_temp = round(max_temp_attr)
+
+        supported_modes = controller_state.attributes.get("hvac_modes", [])
+        mode_options = [
+            mode
+            for mode in supported_modes
+            if mode != HVACMode.OFF
+        ]
+        if not mode_options:
+            mode_options = [controller_state.state]
+
+        if user_input is not None:
+            self.fixed_idle_controller_mode = user_input.get(
+                const.CONF_FIXED_IDLE_CONTROLLER_MODE
+            )
+            self.fixed_idle_controller_temperature = user_input.get(
+                const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE
+            )
+            return await self.async_step_zones()
+
+        default_mode = self.options.get(const.CONF_FIXED_IDLE_CONTROLLER_MODE)
+        if default_mode not in mode_options:
+            default_mode = controller_state.state if controller_state.state in mode_options else mode_options[0]
+
+        default_temperature = self.options.get(const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE)
+        if default_temperature is None:
+            default_temperature = controller_state.attributes.get(ATTR_TEMPERATURE)
+        if default_temperature is None or default_temperature < min_temp or default_temperature > max_temp:
+            default_temperature = min_temp
+
+        return self.async_show_form(
+            step_id="fixed_idle_controller_state",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        const.CONF_FIXED_IDLE_CONTROLLER_MODE,
+                        default=default_mode,
+                    ): vol.In(mode_options),
+                    vol.Required(
+                        const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE,
+                        default=default_temperature,
+                    ): vol.All(
+                        vol.Coerce(float),
+                        vol.Range(min=min_temp, max=max_temp),
+                    ),
+                }
+            ),
         )
 
     async def async_step_zones(self, user_input=None):
@@ -135,9 +244,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         controller_state = self.hass.states.get(self.controller)
         min_temp = 0
         max_temp = 100
-        if self.controller.startswith(Platform.CLIMATE):
-            min_temp = round(controller_state.attributes.get(ATTR_MIN_TEMP))
-            max_temp = round(controller_state.attributes.get(ATTR_MAX_TEMP))
+        if self.controller and self.controller.startswith(Platform.CLIMATE) and controller_state:
+            min_temp_attr = controller_state.attributes.get(ATTR_MIN_TEMP)
+            max_temp_attr = controller_state.attributes.get(ATTR_MAX_TEMP)
+            if isinstance(min_temp_attr, (int, float)):
+                min_temp = round(min_temp_attr)
+            if isinstance(max_temp_attr, (int, float)):
+                max_temp = round(max_temp_attr)
 
         default = self.options.get(const.CONF_MAX_SETPOINT)
         if not default or default < min_temp or default > max_temp:
@@ -194,6 +307,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 const.CONF_MAX_SETPOINT: self.max_setpoint,
                 const.CONF_CONTROLLER_DELAY_TIME: self.controller_delay_time,
                 const.CONF_HYSTERESIS: getattr(self, "hysteresis", const.DEFAULT_HYSTERESIS),
+                const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE: (
+                    self.use_fixed_idle_controller_state
+                    if self.use_fixed_idle_controller_state is not None
+                    else self.options.get(
+                        const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE,
+                        const.DEFAULT_USE_FIXED_IDLE_CONTROLLER_STATE,
+                    )
+                ),
+                const.CONF_FIXED_IDLE_CONTROLLER_MODE: self.fixed_idle_controller_mode,
+                const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE: self.fixed_idle_controller_temperature,
             })
 
         default = self.options.get(const.CONF_CONTROLLER_DELAY_TIME)

--- a/custom_components/zoned_heating/config_flow.py
+++ b/custom_components/zoned_heating/config_flow.py
@@ -59,9 +59,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self.zones = None
         self.max_setpoint = None
         self.controller_delay_time = None
-        self.use_fixed_idle_controller_state = None
-        self.fixed_idle_controller_mode = None
-        self.fixed_idle_controller_temperature = None
+        self.use_fixed_controller_restoration_setting = None
+        self.fixed_controller_restoration_mode = None
+        self.fixed_controller_restoration_setpoint = None
 
     async def async_step_init(self, user_input=None):
         """Handle options flow."""
@@ -69,11 +69,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             self.controller = user_input.get(const.CONF_CONTROLLER)
             if not self.controller.startswith(Platform.CLIMATE):
-                self.use_fixed_idle_controller_state = False
-                self.fixed_idle_controller_mode = None
-                self.fixed_idle_controller_temperature = None
+                self.use_fixed_controller_restoration_setting = False
+                self.fixed_controller_restoration_mode = None
+                self.fixed_controller_restoration_setpoint = None
                 return await self.async_step_zones()
-            return await self.async_step_controller_idle_state()
+            return await self.async_step_controller_restoration_setting()
 
         all_climates = [
             climate
@@ -101,43 +101,43 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             )
         )
 
-    async def async_step_controller_idle_state(self, user_input=None):
-        """Handle controller idle state strategy option."""
+    async def async_step_controller_restoration_setting(self, user_input=None):
+        """Handle controller restoration setting strategy option."""
 
         if user_input is not None:
-            self.use_fixed_idle_controller_state = user_input.get(
-                const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE
+            self.use_fixed_controller_restoration_setting = user_input.get(
+                const.CONF_USE_FIXED_CONTROLLER_RESTORATION_SETTING
             )
             if not self.controller.startswith(Platform.CLIMATE):
-                self.use_fixed_idle_controller_state = False
-            if self.use_fixed_idle_controller_state and self.controller.startswith(Platform.CLIMATE):
-                return await self.async_step_fixed_idle_controller_state()
+                self.use_fixed_controller_restoration_setting = False
+            if self.use_fixed_controller_restoration_setting and self.controller.startswith(Platform.CLIMATE):
+                return await self.async_step_fixed_controller_restoration_setting()
 
-            self.fixed_idle_controller_mode = None
-            self.fixed_idle_controller_temperature = None
+            self.fixed_controller_restoration_mode = None
+            self.fixed_controller_restoration_setpoint = None
             return await self.async_step_zones()
 
         default = self.options.get(
-            const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE,
-            const.DEFAULT_USE_FIXED_IDLE_CONTROLLER_STATE,
+            const.CONF_USE_FIXED_CONTROLLER_RESTORATION_SETTING,
+            const.DEFAULT_USE_FIXED_CONTROLLER_RESTORATION_SETTING,
         )
         if not self.controller.startswith(Platform.CLIMATE):
             default = False
 
         schema = {
             vol.Required(
-                const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE,
+                const.CONF_USE_FIXED_CONTROLLER_RESTORATION_SETTING,
                 default=default,
             ): bool
         }
 
         return self.async_show_form(
-            step_id="controller_idle_state",
+            step_id="controller_restoration_setting",
             data_schema=vol.Schema(schema),
         )
 
-    async def async_step_fixed_idle_controller_state(self, user_input=None):
-        """Handle fixed controller idle mode and temperature options."""
+    async def async_step_fixed_controller_restoration_setting(self, user_input=None):
+        """Handle fixed controller restoration mode and temperature options."""
 
         controller_state = self.hass.states.get(self.controller)
         if controller_state is None:
@@ -163,35 +163,35 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             mode_options = [controller_state.state]
 
         if user_input is not None:
-            self.fixed_idle_controller_mode = user_input.get(
-                const.CONF_FIXED_IDLE_CONTROLLER_MODE
+            self.fixed_controller_restoration_mode = user_input.get(
+                const.CONF_FIXED_CONTROLLER_RESTORATION_MODE
             )
-            self.fixed_idle_controller_temperature = user_input.get(
-                const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE
+            self.fixed_controller_restoration_setpoint = user_input.get(
+                const.CONF_FIXED_CONTROLLER_RESTORATION_SETPOINT
             )
             return await self.async_step_zones()
 
-        default_mode = self.options.get(const.CONF_FIXED_IDLE_CONTROLLER_MODE)
+        default_mode = self.options.get(const.CONF_FIXED_CONTROLLER_RESTORATION_MODE)
         if default_mode not in mode_options:
             default_mode = controller_state.state if controller_state.state in mode_options else mode_options[0]
 
-        default_temperature = self.options.get(const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE)
-        if default_temperature is None:
-            default_temperature = controller_state.attributes.get(ATTR_TEMPERATURE)
-        if default_temperature is None or default_temperature < min_temp or default_temperature > max_temp:
-            default_temperature = min_temp
+        default_setpoint = self.options.get(const.CONF_FIXED_CONTROLLER_RESTORATION_SETPOINT)
+        if default_setpoint is None:
+            default_setpoint = controller_state.attributes.get(ATTR_TEMPERATURE)
+        if default_setpoint is None or default_setpoint < min_temp or default_setpoint > max_temp:
+            default_setpoint = min_temp
 
         return self.async_show_form(
-            step_id="fixed_idle_controller_state",
+            step_id="fixed_controller_restoration_setting",
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        const.CONF_FIXED_IDLE_CONTROLLER_MODE,
+                        const.CONF_FIXED_CONTROLLER_RESTORATION_MODE,
                         default=default_mode,
                     ): vol.In(mode_options),
                     vol.Required(
-                        const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE,
-                        default=default_temperature,
+                        const.CONF_FIXED_CONTROLLER_RESTORATION_SETPOINT,
+                        default=default_setpoint,
                     ): vol.All(
                         vol.Coerce(float),
                         vol.Range(min=min_temp, max=max_temp),
@@ -307,16 +307,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 const.CONF_MAX_SETPOINT: self.max_setpoint,
                 const.CONF_CONTROLLER_DELAY_TIME: self.controller_delay_time,
                 const.CONF_HYSTERESIS: getattr(self, "hysteresis", const.DEFAULT_HYSTERESIS),
-                const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE: (
-                    self.use_fixed_idle_controller_state
-                    if self.use_fixed_idle_controller_state is not None
+                const.CONF_USE_FIXED_CONTROLLER_RESTORATION_SETTING: (
+                    self.use_fixed_controller_restoration_setting
+                    if self.use_fixed_controller_restoration_setting is not None
                     else self.options.get(
-                        const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE,
-                        const.DEFAULT_USE_FIXED_IDLE_CONTROLLER_STATE,
+                        const.CONF_USE_FIXED_CONTROLLER_RESTORATION_SETTING,
+                        const.DEFAULT_USE_FIXED_CONTROLLER_RESTORATION_SETTING,
                     )
                 ),
-                const.CONF_FIXED_IDLE_CONTROLLER_MODE: self.fixed_idle_controller_mode,
-                const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE: self.fixed_idle_controller_temperature,
+                const.CONF_FIXED_CONTROLLER_RESTORATION_MODE: self.fixed_controller_restoration_mode,
+                const.CONF_FIXED_CONTROLLER_RESTORATION_SETPOINT: self.fixed_controller_restoration_setpoint,
             })
 
         default = self.options.get(const.CONF_CONTROLLER_DELAY_TIME)

--- a/custom_components/zoned_heating/const.py
+++ b/custom_components/zoned_heating/const.py
@@ -10,10 +10,14 @@ CONF_CONTROLLER = "controller"
 CONF_ZONES = "zones"
 CONF_MAX_SETPOINT = "max_setpoint"
 CONF_CONTROLLER_DELAY_TIME = "controller_delay_time"
+CONF_USE_FIXED_IDLE_CONTROLLER_STATE = "use_fixed_idle_controller_state"
+CONF_FIXED_IDLE_CONTROLLER_MODE = "fixed_idle_controller_mode"
+CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE = "fixed_idle_controller_temperature"
 
 DEFAULT_MAX_SETPOINT = 21
 DEFAULT_CONTROLLER_DELAY_TIME = 10
 DEFAULT_HYSTERESIS = 1
+DEFAULT_USE_FIXED_IDLE_CONTROLLER_STATE = False
 CONF_HYSTERESIS = "hysteresis"
 
 ATTR_OVERRIDE_ACTIVE = "override_active"

--- a/custom_components/zoned_heating/const.py
+++ b/custom_components/zoned_heating/const.py
@@ -10,14 +10,14 @@ CONF_CONTROLLER = "controller"
 CONF_ZONES = "zones"
 CONF_MAX_SETPOINT = "max_setpoint"
 CONF_CONTROLLER_DELAY_TIME = "controller_delay_time"
-CONF_USE_FIXED_IDLE_CONTROLLER_STATE = "use_fixed_idle_controller_state"
-CONF_FIXED_IDLE_CONTROLLER_MODE = "fixed_idle_controller_mode"
-CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE = "fixed_idle_controller_temperature"
+CONF_USE_FIXED_CONTROLLER_RESTORATION_SETTING = "use_fixed_controller_restoration_setting"
+CONF_FIXED_CONTROLLER_RESTORATION_MODE = "fixed_controller_restoration_mode"
+CONF_FIXED_CONTROLLER_RESTORATION_SETPOINT = "fixed_controller_restoration_setpoint"
 
 DEFAULT_MAX_SETPOINT = 21
 DEFAULT_CONTROLLER_DELAY_TIME = 10
 DEFAULT_HYSTERESIS = 1
-DEFAULT_USE_FIXED_IDLE_CONTROLLER_STATE = False
+DEFAULT_USE_FIXED_CONTROLLER_RESTORATION_SETTING = False
 CONF_HYSTERESIS = "hysteresis"
 
 ATTR_OVERRIDE_ACTIVE = "override_active"

--- a/custom_components/zoned_heating/switch.py
+++ b/custom_components/zoned_heating/switch.py
@@ -53,23 +53,46 @@ async def async_setup_entry(
     max_setpoint = config_entry.options.get(const.CONF_MAX_SETPOINT)
     controller_delay_time = config_entry.options.get(const.CONF_CONTROLLER_DELAY_TIME, const.DEFAULT_CONTROLLER_DELAY_TIME)
     hysteresis = config_entry.options.get(const.CONF_HYSTERESIS, config_entry.data.get(const.CONF_HYSTERESIS, const.DEFAULT_HYSTERESIS))
+    use_fixed_idle_controller_state = config_entry.options.get(
+        const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE,
+        const.DEFAULT_USE_FIXED_IDLE_CONTROLLER_STATE,
+    )
+    fixed_idle_controller_mode = config_entry.options.get(const.CONF_FIXED_IDLE_CONTROLLER_MODE)
+    fixed_idle_controller_temperature = config_entry.options.get(const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE)
 
-    async_add_entities([
-        ZonedHeaterSwitch(hass, controller, zones, max_setpoint, controller_delay_time, hysteresis)
-    ])
+    entity = ZonedHeaterSwitch(hass,controller, zones, max_setpoint, controller_delay_time, hysteresis, use_fixed_idle_controller_state, fixed_idle_controller_mode, fixed_idle_controller_temperature)
+    async_add_entities([entity])
+
+    # Store reference to the created entity so update listener can find it
+    hass.data.setdefault(const.DOMAIN, {}).setdefault(config_entry.entry_id, {})
+    hass.data[const.DOMAIN][config_entry.entry_id]["entity"] = entity
+
+    async def _async_options_updated(hass, entry):
+        # find the platform entity instance and call its update method if present
+        ent = hass.data[const.DOMAIN].get(entry.entry_id, {}).get("entity")
+        if ent:
+            await ent.async_options_updated(entry.options)
+
+    config_entry.add_update_listener(_async_options_updated)
 
 
 class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
 
     _attr_name = "Zoned Heating"
 
-    def __init__(self, hass, controller_entity, zone_entities, max_setpoint, controller_delay_time, hysteresis):
+    def __init__(self, hass, controller_entity, zone_entities, max_setpoint, controller_delay_time, hysteresis, use_fixed_idle_controller_state, fixed_idle_controller_mode, fixed_idle_controller_temperature):
         self.hass = hass
         self._controller_entity = controller_entity
         self._zone_entities = zone_entities
         self._max_setpoint = max_setpoint
         self._controller_delay_time = controller_delay_time
         self._hysteresis = hysteresis
+        self._use_fixed_idle_controller_state = (
+            use_fixed_idle_controller_state and
+            compute_domain(controller_entity) == Platform.CLIMATE
+        )
+        self._fixed_idle_controller_mode = fixed_idle_controller_mode
+        self._fixed_idle_controller_temperature = fixed_idle_controller_temperature
 
         self._enabled = None
         self._state_listeners = []
@@ -89,9 +112,16 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         if state:
             _LOGGER.debug("Restored data prior to restart: %s", state.attributes)
             self._enabled = state.state == STATE_ON
-            self._override_active = state.attributes.get(const.ATTR_OVERRIDE_ACTIVE)
-            self._temperature_increase = state.attributes.get(const.ATTR_TEMPERATURE_INCREASE)
-            self._stored_controller_setpoint = state.attributes.get(const.ATTR_STORED_CONTROLLER_SETPOINT)
+            self._override_active = bool(state.attributes.get(const.ATTR_OVERRIDE_ACTIVE))
+            try:
+                self._temperature_increase = float(state.attributes.get(const.ATTR_TEMPERATURE_INCREASE) or 0)
+            except Exception:
+                self._temperature_increase = 0
+            try:
+                scs = state.attributes.get(const.ATTR_STORED_CONTROLLER_SETPOINT)
+                self._stored_controller_setpoint = float(scs) if scs is not None else None
+            except Exception:
+                self._stored_controller_setpoint = None
             self._stored_controller_state = state.attributes.get(const.ATTR_STORED_CONTROLLER_STATE)
         else:
             self._enabled = True
@@ -110,7 +140,7 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         return self._enabled
 
     @property
-    def state_attributes(self):
+    def extra_state_attributes(self):
         """Return the data of the entity."""
         return {
             const.CONF_CONTROLLER: self._controller_entity,
@@ -118,6 +148,9 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
             const.CONF_MAX_SETPOINT: self._max_setpoint,
             const.CONF_CONTROLLER_DELAY_TIME: self._controller_delay_time,
             const.CONF_HYSTERESIS: self._hysteresis,
+            const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE: self._use_fixed_idle_controller_state,
+            const.CONF_FIXED_IDLE_CONTROLLER_MODE: self._fixed_idle_controller_mode,
+            const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE: self._fixed_idle_controller_temperature,
             const.ATTR_OVERRIDE_ACTIVE: self._override_active,
             const.ATTR_TEMPERATURE_INCREASE: self._temperature_increase,
             const.ATTR_STORED_CONTROLLER_STATE: self._stored_controller_state,
@@ -161,6 +194,33 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         ]
         _LOGGER.debug("Registered state listeners for controller=%s zones=%s", self._controller_entity, self._zone_entities)
 
+    async def async_options_updated(self, options: dict):
+        """Update runtime options from a config entry without reloading."""
+        self._controller_entity = options.get(const.CONF_CONTROLLER)
+        self._zone_entities = options.get(const.CONF_ZONES, [])
+        self._max_setpoint = options.get(const.CONF_MAX_SETPOINT, self._max_setpoint)
+        self._controller_delay_time = options.get(
+            const.CONF_CONTROLLER_DELAY_TIME, self._controller_delay_time
+        )
+        self._hysteresis = options.get(const.CONF_HYSTERESIS, self._hysteresis)
+        use_fixed = options.get(
+            const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE,
+            const.DEFAULT_USE_FIXED_IDLE_CONTROLLER_STATE,
+        )
+        self._use_fixed_idle_controller_state = (
+            use_fixed and compute_domain(self._controller_entity) == Platform.CLIMATE
+        )
+        self._fixed_idle_controller_mode = options.get(const.CONF_FIXED_IDLE_CONTROLLER_MODE)
+        self._fixed_idle_controller_temperature = options.get(const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE)
+
+        _LOGGER.debug("Config options updated: controller=%s zones=%s use_fixed=%s", self._controller_entity, self._zone_entities, self._use_fixed_idle_controller_state)
+
+        if self._enabled:
+            await self.async_start_state_listeners()
+
+        await self.async_calculate_override()
+        self.async_write_ha_state()
+
     async def async_stop_state_listeners(self):
         """stop watching for state changes of controller / zone entities"""
         while len(self._state_listeners):
@@ -168,7 +228,12 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
 
     async def async_controller_state_changed(self, event):
         """fired when controller entity changes"""
-        if self._ignore_controller_state_change_timer or not self._override_active:
+        if self._ignore_controller_state_change_timer:
+            return
+
+        if not self._override_active:
+            if self._use_fixed_idle_controller_state:
+                await self.async_apply_fixed_idle_controller_state()
             return
         old_state = parse_state(event.data["old_state"])
         new_state = parse_state(event.data["new_state"])
@@ -277,6 +342,8 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
             self._temperature_increase == temperature_increase and
             override_active == self._override_active
         ):
+            if self._use_fixed_idle_controller_state and not override_active:
+                await self.async_apply_fixed_idle_controller_state()
             # nothing to do
             return
 
@@ -301,9 +368,13 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         self._override_active = True
         current_state = parse_state(self.hass.states.get(self._controller_entity))
         # store current controller entity settings for later
-        _LOGGER.debug("Storing controller state=%s", current_state)
-        self._stored_controller_state = current_state[ATTR_HVAC_MODE]
-        self._stored_controller_setpoint = current_state[ATTR_TEMPERATURE]
+        if self._use_fixed_idle_controller_state:
+            self._stored_controller_state = None
+            self._stored_controller_setpoint = None
+        else:
+            _LOGGER.debug("Storing controller state=%s", current_state)
+            self._stored_controller_state = current_state[ATTR_HVAC_MODE]
+            self._stored_controller_setpoint = current_state[ATTR_TEMPERATURE]
 
         if current_state[ATTR_HVAC_MODE] != HVACMode.HEAT:
             # uupdate to heat mode if needed
@@ -324,7 +395,13 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         self._override_active = False
         self._temperature_increase = 0
 
-        current_state = parse_state(self.hass.states.get(self.entity_id))
+        if self._use_fixed_idle_controller_state:
+            await self.async_apply_fixed_idle_controller_state()
+            self._stored_controller_setpoint = None
+            self._stored_controller_state = None
+            return
+
+        current_state = parse_state(self.hass.states.get(self._controller_entity))
 
         if current_state[ATTR_HVAC_MODE] != self._stored_controller_state and self._stored_controller_state is not None:
             if compute_domain(self._controller_entity) == Platform.CLIMATE:
@@ -341,6 +418,37 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
 
         self._stored_controller_setpoint = None
         self._stored_controller_state = None
+
+    async def async_apply_fixed_idle_controller_state(self):
+        """Apply configured fixed idle state on the controller when override is inactive."""
+
+        if (
+            not self._use_fixed_idle_controller_state or
+            compute_domain(self._controller_entity) != Platform.CLIMATE
+        ):
+            return
+
+        controller_state = self.hass.states.get(self._controller_entity)
+        current_state = parse_state(controller_state)
+
+        if (
+            self._fixed_idle_controller_mode and
+            current_state[ATTR_HVAC_MODE] != self._fixed_idle_controller_mode
+        ):
+            _LOGGER.debug("Applying fixed idle HVAC mode %s to %s", self._fixed_idle_controller_mode, self._controller_entity)
+            await self._ignore_controller_state_changes()
+            await async_set_hvac_mode(
+                self.hass,
+                self._controller_entity,
+                self._fixed_idle_controller_mode,
+            )
+
+        if isinstance(self._fixed_idle_controller_temperature, (int, float)):
+            target = float(self._fixed_idle_controller_temperature)
+            if current_state[ATTR_TEMPERATURE] != target:
+                _LOGGER.debug("Applying fixed idle temperature %s to %s", target, self._controller_entity)
+                await self._ignore_controller_state_changes()
+                await async_set_temperature(self.hass, self._controller_entity, target)
 
     async def async_update_override_setpoint(self, temperature_increase: float):
         """Update the override setpoint of the controller"""

--- a/custom_components/zoned_heating/switch.py
+++ b/custom_components/zoned_heating/switch.py
@@ -53,14 +53,14 @@ async def async_setup_entry(
     max_setpoint = config_entry.options.get(const.CONF_MAX_SETPOINT)
     controller_delay_time = config_entry.options.get(const.CONF_CONTROLLER_DELAY_TIME, const.DEFAULT_CONTROLLER_DELAY_TIME)
     hysteresis = config_entry.options.get(const.CONF_HYSTERESIS, config_entry.data.get(const.CONF_HYSTERESIS, const.DEFAULT_HYSTERESIS))
-    use_fixed_idle_controller_state = config_entry.options.get(
-        const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE,
-        const.DEFAULT_USE_FIXED_IDLE_CONTROLLER_STATE,
+    use_fixed_controller_restoration_setting = config_entry.options.get(
+        const.CONF_USE_FIXED_CONTROLLER_RESTORATION_SETTING,
+        const.DEFAULT_USE_FIXED_CONTROLLER_RESTORATION_SETTING,
     )
-    fixed_idle_controller_mode = config_entry.options.get(const.CONF_FIXED_IDLE_CONTROLLER_MODE)
-    fixed_idle_controller_temperature = config_entry.options.get(const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE)
+    fixed_controller_restoration_mode = config_entry.options.get(const.CONF_FIXED_CONTROLLER_RESTORATION_MODE)
+    fixed_controller_restoration_setpoint = config_entry.options.get(const.CONF_FIXED_CONTROLLER_RESTORATION_SETPOINT)
 
-    entity = ZonedHeaterSwitch(hass,controller, zones, max_setpoint, controller_delay_time, hysteresis, use_fixed_idle_controller_state, fixed_idle_controller_mode, fixed_idle_controller_temperature)
+    entity = ZonedHeaterSwitch(hass, controller, zones, max_setpoint, controller_delay_time, hysteresis, use_fixed_controller_restoration_setting, fixed_controller_restoration_mode, fixed_controller_restoration_setpoint)
     async_add_entities([entity])
 
     # Store reference to the created entity so update listener can find it
@@ -80,27 +80,36 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
 
     _attr_name = "Zoned Heating"
 
-    def __init__(self, hass, controller_entity, zone_entities, max_setpoint, controller_delay_time, hysteresis, use_fixed_idle_controller_state, fixed_idle_controller_mode, fixed_idle_controller_temperature):
+    def __init__(self, hass, controller_entity, zone_entities, max_setpoint, controller_delay_time, hysteresis, use_fixed_controller_restoration_setting, fixed_controller_restoration_mode, fixed_controller_restoration_setpoint):
         self.hass = hass
         self._controller_entity = controller_entity
         self._zone_entities = zone_entities
         self._max_setpoint = max_setpoint
         self._controller_delay_time = controller_delay_time
         self._hysteresis = hysteresis
-        self._use_fixed_idle_controller_state = (
-            use_fixed_idle_controller_state and
+        self._use_fixed_controller_restoration_setting = (
+            use_fixed_controller_restoration_setting and
             compute_domain(controller_entity) == Platform.CLIMATE
         )
-        self._fixed_idle_controller_mode = fixed_idle_controller_mode
-        self._fixed_idle_controller_temperature = fixed_idle_controller_temperature
 
         self._enabled = None
         self._state_listeners = []
         self._ignore_controller_state_change_timer = None
         self._override_active = False
         self._temperature_increase = 0
-        self._stored_controller_setpoint = None
-        self._stored_controller_state = None
+
+        # Pre-populate stored values with the fixed restoration settings when enabled.
+        # These persist across override cycles so async_stop_override_mode and
+        # async_apply_controller_restoration_setting always have the correct target.
+        if self._use_fixed_controller_restoration_setting:
+            self._stored_controller_state = fixed_controller_restoration_mode
+            self._stored_controller_setpoint = (
+                float(fixed_controller_restoration_setpoint)
+                if fixed_controller_restoration_setpoint is not None else None
+            )
+        else:
+            self._stored_controller_state = None
+            self._stored_controller_setpoint = None
 
         super().__init__()
 
@@ -148,9 +157,7 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
             const.CONF_MAX_SETPOINT: self._max_setpoint,
             const.CONF_CONTROLLER_DELAY_TIME: self._controller_delay_time,
             const.CONF_HYSTERESIS: self._hysteresis,
-            const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE: self._use_fixed_idle_controller_state,
-            const.CONF_FIXED_IDLE_CONTROLLER_MODE: self._fixed_idle_controller_mode,
-            const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE: self._fixed_idle_controller_temperature,
+            const.CONF_USE_FIXED_CONTROLLER_RESTORATION_SETTING: self._use_fixed_controller_restoration_setting,
             const.ATTR_OVERRIDE_ACTIVE: self._override_active,
             const.ATTR_TEMPERATURE_INCREASE: self._temperature_increase,
             const.ATTR_STORED_CONTROLLER_STATE: self._stored_controller_state,
@@ -204,16 +211,20 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         )
         self._hysteresis = options.get(const.CONF_HYSTERESIS, self._hysteresis)
         use_fixed = options.get(
-            const.CONF_USE_FIXED_IDLE_CONTROLLER_STATE,
-            const.DEFAULT_USE_FIXED_IDLE_CONTROLLER_STATE,
+            const.CONF_USE_FIXED_CONTROLLER_RESTORATION_SETTING,
+            const.DEFAULT_USE_FIXED_CONTROLLER_RESTORATION_SETTING,
         )
-        self._use_fixed_idle_controller_state = (
+        self._use_fixed_controller_restoration_setting = (
             use_fixed and compute_domain(self._controller_entity) == Platform.CLIMATE
         )
-        self._fixed_idle_controller_mode = options.get(const.CONF_FIXED_IDLE_CONTROLLER_MODE)
-        self._fixed_idle_controller_temperature = options.get(const.CONF_FIXED_IDLE_CONTROLLER_TEMPERATURE)
 
-        _LOGGER.debug("Config options updated: controller=%s zones=%s use_fixed=%s", self._controller_entity, self._zone_entities, self._use_fixed_idle_controller_state)
+        # Sync stored restoration target with (possibly updated) fixed values.
+        if self._use_fixed_controller_restoration_setting:
+            self._stored_controller_state = options.get(const.CONF_FIXED_CONTROLLER_RESTORATION_MODE)
+            raw = options.get(const.CONF_FIXED_CONTROLLER_RESTORATION_SETPOINT)
+            self._stored_controller_setpoint = float(raw) if raw is not None else None
+
+        _LOGGER.debug("Config options updated: controller=%s zones=%s use_fixed=%s", self._controller_entity, self._zone_entities, self._use_fixed_controller_restoration_setting)
 
         if self._enabled:
             await self.async_start_state_listeners()
@@ -232,8 +243,8 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
             return
 
         if not self._override_active:
-            if self._use_fixed_idle_controller_state:
-                await self.async_apply_fixed_idle_controller_state()
+            if self._use_fixed_controller_restoration_setting:
+                await self.async_apply_controller_restoration_setting()
             return
         old_state = parse_state(event.data["old_state"])
         new_state = parse_state(event.data["new_state"])
@@ -342,8 +353,8 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
             self._temperature_increase == temperature_increase and
             override_active == self._override_active
         ):
-            if self._use_fixed_idle_controller_state and not override_active:
-                await self.async_apply_fixed_idle_controller_state()
+            if self._use_fixed_controller_restoration_setting and not override_active:
+                await self.async_apply_controller_restoration_setting()
             # nothing to do
             return
 
@@ -367,17 +378,16 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
 
         self._override_active = True
         current_state = parse_state(self.hass.states.get(self._controller_entity))
-        # store current controller entity settings for later
-        if self._use_fixed_idle_controller_state:
-            self._stored_controller_state = None
-            self._stored_controller_setpoint = None
-        else:
+
+        # When using fixed restoration settings, stored values are already set to the
+        # fixed target — don't overwrite them with the live controller state.
+        if not self._use_fixed_controller_restoration_setting:
             _LOGGER.debug("Storing controller state=%s", current_state)
             self._stored_controller_state = current_state[ATTR_HVAC_MODE]
             self._stored_controller_setpoint = current_state[ATTR_TEMPERATURE]
 
         if current_state[ATTR_HVAC_MODE] != HVACMode.HEAT:
-            # uupdate to heat mode if needed
+            # update to heat mode if needed
             await self._ignore_controller_state_changes()
             if compute_domain(self._controller_entity) == Platform.CLIMATE:
                 await async_set_hvac_mode(self.hass, self._controller_entity, HVACMode.HEAT)
@@ -387,7 +397,7 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         await self.async_update_override_setpoint(temperature_increase)
 
     async def async_stop_override_mode(self):
-        """Stop the override of the controller and revert its prior settings"""
+        """Stop the override of the controller and restore it to the stored settings."""
         if not self._override_active:
             return
 
@@ -395,15 +405,9 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         self._override_active = False
         self._temperature_increase = 0
 
-        if self._use_fixed_idle_controller_state:
-            await self.async_apply_fixed_idle_controller_state()
-            self._stored_controller_setpoint = None
-            self._stored_controller_state = None
-            return
-
         current_state = parse_state(self.hass.states.get(self._controller_entity))
 
-        if current_state[ATTR_HVAC_MODE] != self._stored_controller_state and self._stored_controller_state is not None:
+        if self._stored_controller_state is not None and current_state[ATTR_HVAC_MODE] != self._stored_controller_state:
             if compute_domain(self._controller_entity) == Platform.CLIMATE:
                 await async_set_hvac_mode(self.hass, self._controller_entity, self._stored_controller_state)
             elif compute_domain(self._controller_entity) == Platform.SWITCH:
@@ -416,14 +420,20 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         ):
             await async_set_temperature(self.hass, self._controller_entity, self._stored_controller_setpoint)
 
-        self._stored_controller_setpoint = None
-        self._stored_controller_state = None
+        # Keep stored values for fixed mode (reused on next override cycle and by
+        # async_apply_controller_restoration_setting). Clear only for dynamic mode.
+        if not self._use_fixed_controller_restoration_setting:
+            self._stored_controller_setpoint = None
+            self._stored_controller_state = None
 
-    async def async_apply_fixed_idle_controller_state(self):
-        """Apply configured fixed idle state on the controller when override is inactive."""
+    async def async_apply_controller_restoration_setting(self):
+        """Re-apply the stored restoration setting to the controller while override is inactive.
 
+        Called whenever the controller reports a state change during idle to guard
+        against external modifications drifting away from the configured target.
+        """
         if (
-            not self._use_fixed_idle_controller_state or
+            not self._use_fixed_controller_restoration_setting or
             compute_domain(self._controller_entity) != Platform.CLIMATE
         ):
             return
@@ -432,21 +442,21 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         current_state = parse_state(controller_state)
 
         if (
-            self._fixed_idle_controller_mode and
-            current_state[ATTR_HVAC_MODE] != self._fixed_idle_controller_mode
+            self._stored_controller_state and
+            current_state[ATTR_HVAC_MODE] != self._stored_controller_state
         ):
-            _LOGGER.debug("Applying fixed idle HVAC mode %s to %s", self._fixed_idle_controller_mode, self._controller_entity)
+            _LOGGER.debug("Applying restoration HVAC mode %s to %s", self._stored_controller_state, self._controller_entity)
             await self._ignore_controller_state_changes()
             await async_set_hvac_mode(
                 self.hass,
                 self._controller_entity,
-                self._fixed_idle_controller_mode,
+                self._stored_controller_state,
             )
 
-        if isinstance(self._fixed_idle_controller_temperature, (int, float)):
-            target = float(self._fixed_idle_controller_temperature)
+        if isinstance(self._stored_controller_setpoint, (int, float)):
+            target = float(self._stored_controller_setpoint)
             if current_state[ATTR_TEMPERATURE] != target:
-                _LOGGER.debug("Applying fixed idle temperature %s to %s", target, self._controller_entity)
+                _LOGGER.debug("Applying restoration temperature %s to %s", target, self._controller_entity)
                 await self._ignore_controller_state_changes()
                 await async_set_temperature(self.hass, self._controller_entity, target)
 
@@ -519,7 +529,7 @@ class ZonedHeaterSwitch(ToggleEntity, RestoreEntity):
         delay = datetime.timedelta(seconds=self._controller_delay_time)
 
         @callback
-        async def timer_finished(now):
+        def timer_finished(_now):
             _LOGGER.debug("stop ignoring controller state changes")
             self._ignore_controller_state_change_timer = None
 

--- a/custom_components/zoned_heating/translations/en.json
+++ b/custom_components/zoned_heating/translations/en.json
@@ -8,6 +8,21 @@
           "controller": "Controller entity"
         }
       },
+      "controller_idle_state": {
+        "title": "Configure Zoned Heating settings",
+        "description": "If there are TRVs in the same room as the controller thermostat, enable fixed idle state so zoned heating always returns the controller to a predictable mode and setpoint when inactive.",
+        "data": {
+          "use_fixed_idle_controller_state": "Use fixed controller idle mode + temperature (recommended with TRVs in controller room)"
+        }
+      },
+      "fixed_idle_controller_state": {
+        "title": "Configure Zoned Heating settings",
+        "description": "Choose the controller idle mode and setpoint that zoned heating should enforce while inactive.",
+        "data": {
+          "fixed_idle_controller_mode": "Controller idle HVAC mode",
+          "fixed_idle_controller_temperature": "Controller idle temperature"
+        }
+      },
       "zones": {
         "title": "Configure Zoned Heating settings",
         "description": "Choose devices which control the zones",

--- a/custom_components/zoned_heating/translations/en.json
+++ b/custom_components/zoned_heating/translations/en.json
@@ -8,19 +8,19 @@
           "controller": "Controller entity"
         }
       },
-      "controller_idle_state": {
+      "controller_restoration_setting": {
         "title": "Configure Zoned Heating settings",
-        "description": "If there are TRVs in the same room as the controller thermostat, enable fixed idle state so zoned heating always returns the controller to a predictable mode and setpoint when inactive.",
+        "description": "Use fixed settings for restoring controller after override mode, instead of storing controller settings prior to starting override mode. Recommended when TRVs are present in the same room as the controller thermostat.",
         "data": {
-          "use_fixed_idle_controller_state": "Use fixed controller idle mode + temperature (recommended with TRVs in controller room)"
+          "use_fixed_controller_restoration_setting": "Use fixed controller restoration mode + temperature (recommended with TRVs in controller room)"
         }
       },
-      "fixed_idle_controller_state": {
+      "fixed_controller_restoration_setting": {
         "title": "Configure Zoned Heating settings",
-        "description": "Choose the controller idle mode and setpoint that zoned heating should enforce while inactive.",
+        "description": "Choose the controller mode and setpoint that zoned heating will restore after override mode ends.",
         "data": {
-          "fixed_idle_controller_mode": "Controller idle HVAC mode",
-          "fixed_idle_controller_temperature": "Controller idle temperature"
+          "fixed_controller_restoration_mode": "Controller restoration HVAC mode",
+          "fixed_controller_restoration_setpoint": "Controller restoration temperature setpoint"
         }
       },
       "zones": {

--- a/custom_components/zoned_heating/util.py
+++ b/custom_components/zoned_heating/util.py
@@ -121,4 +121,6 @@ async def async_set_switch_state(hass: HomeAssistant, entity_ids, state: str):
 
 
 def compute_domain(entity_id: str):
-    return entity_id.split(".").pop(0)
+    if not entity_id or "." not in entity_id:
+        return None
+    return entity_id.split(".", 1)[0]

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,9 @@ The Zoned heating integration creates a switch entity `switch.zoned_heating` whi
 * `On`: Zoned heating is enabled, the integration watches the zones for heat demand and controls the controller accordingly.
 * `Off`: Zoned heating is disabled, zones are independent from the controller.
 
+### Fixed idle controller mode (TRV rooms)
+If you have TRVs in the same room as the thermostat that controls the boiler, the thermostat's own internal behaviour can conflict with TRV adjustments. Use the "fixed controller mode/temperature" option in the integration options to force the controller to a predictable HVAC mode and setpoint while Zoned Heating is inactive.
+
 ### Attributes
 The `switch.zoned_heating` entity exposes the following attributes:
 
@@ -74,4 +77,3 @@ The following limitations are known and possibly addressed in future updates:
 * The integration is only tested for `climate` modes `heat` and `off`. Modes `cool` and `heat_cool` might result in unwanted behaviour.
 * The override logic assumes that your zones can heat up quicker than the controller. If this is not the case, the zones may never reach the desired temperature.
 * This integration does not handle presets for `climate` devices.
-


### PR DESCRIPTION
Tested locally with the fixed controller mode enabled and it did not trigger my failsafe automation to 'reset' my controller. 

copilot also proposed to make the settings update without reloading to which I said yes but that is above my knowledge of HASS integrations :)